### PR TITLE
Added the ability to specify an external camelizer

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const camelCase = require('camelcase');
 const has = (arr, key) => arr.some(x => typeof x === 'string' ? x === key : x.test(key));
 
 module.exports = (input, opts) => {
-	const fn = opts.camelCase || camelCase
+	const fn = opts.camelCase || camelCase;
 	opts = Object.assign({
 		exclude: [],
 		deep: false

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const has = (arr, key) => arr.some(x => typeof x === 'string' ? x === key : x.te
 module.exports = (input, opts) => {
 	opts = Object.assign({
 		exclude: [],
-		deep: false
+		deep: false,
 		camelCase: camelCase
 	}, opts);
 

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ module.exports = (input, opts) => {
 	opts = Object.assign({
 		exclude: [],
 		deep: false
+		camelCase: camelCase
 	}, opts);
-	const fn = opts.camelCase || camelCase;
 
 	return mapObj(input, (key, val) => {
-		key = has(opts.exclude, key) ? key : fn(key);
+		key = has(opts.exclude, key) ? key : ops.camelCase(key);
 		return [key, val];
 	}, {deep: opts.deep});
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const camelCase = require('camelcase');
 const has = (arr, key) => arr.some(x => typeof x === 'string' ? x === key : x.test(key));
 
 module.exports = (input, opts) => {
-	let fn = opts.camelCase || camelCase
+	const fn = opts.camelCase || camelCase
 	opts = Object.assign({
 		exclude: [],
 		deep: false

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (input, opts) => {
 	opts = Object.assign({
 		exclude: [],
 		deep: false,
-		camelCase: camelCase
+		camelCase
 	}, opts);
 
 	return mapObj(input, (key, val) => {

--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ const camelCase = require('camelcase');
 const has = (arr, key) => arr.some(x => typeof x === 'string' ? x === key : x.test(key));
 
 module.exports = (input, opts) => {
-	const fn = opts.camelCase || camelCase;
 	opts = Object.assign({
 		exclude: [],
 		deep: false
 	}, opts);
+	const fn = opts.camelCase || camelCase;
 
 	return mapObj(input, (key, val) => {
 		key = has(opts.exclude, key) ? key : fn(key);

--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@ const camelCase = require('camelcase');
 const has = (arr, key) => arr.some(x => typeof x === 'string' ? x === key : x.test(key));
 
 module.exports = (input, opts) => {
+	let fn = opts.camelCase || camelCase
 	opts = Object.assign({
 		exclude: [],
 		deep: false
 	}, opts);
 
 	return mapObj(input, (key, val) => {
-		key = has(opts.exclude, key) ? key : camelCase(key);
+		key = has(opts.exclude, key) ? key : fn(key);
 		return [key, val];
 	}, {deep: opts.deep});
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (input, opts) => {
 	}, opts);
 
 	return mapObj(input, (key, val) => {
-		key = has(opts.exclude, key) ? key : ops.camelCase(key);
+		key = has(opts.exclude, key) ? key : opts.camelCase(key);
 		return [key, val];
 	}, {deep: opts.deep});
 };

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,13 @@ Default: `false`
 
 Recurse nested objects and objects in arrays.
 
+##### camelCase
+
+Type: `function`<br>
+Default: `false`
+
+A custom function used to camel-case keys.
+
 
 ## License
 


### PR DESCRIPTION
Hola there :)

We've bumped into this module and wanted to use it to implement versioning in some of our responses (think v1 --> snake case / v2 --> camelCase), though we realized it's quite slow as it needs to camelize all keys each and every time.

Wanted to add an option to specify a custom camelizer -- for example this is what we have:

``` js
const camelCase = memoize(require('camelcase'), {primitive: true, length: 1});

camelCaseKeys(obj, {
      deep: true,
      camelCase: memoizedCamelCase,
})
```

Do you need tests?