### PR TITLE
Require Node.js 6 and fix nested arrays being transformed into objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
+  - 'lts/*'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const camelCaseConvert = (input, opts) => {
 		deep: false
 	}, opts);
 
-	const exclude = opts.exclude;
+	const {exclude} = opts;
 
 	return mapObj(input, (key, val) => {
 		if (!(exclude && has(exclude, key))) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "camelcase": "^4.1.0",
-    "map-obj": "^2.0.0",
+    "map-obj": "^3.0.0",
     "quick-lru": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava",

--- a/test.js
+++ b/test.js
@@ -18,6 +18,14 @@ test('deep option', t => {
 	);
 });
 
+test('handles nested arrays', t => {
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		m({q_w_e: [['a', 'b']]}, {deep: true}),
+		{qWE: [['a', 'b']]}
+	);
+});
+
 test('accepts an array of objects', t => {
 	t.deepEqual(
 		// eslint-disable-next-line camelcase


### PR DESCRIPTION
Fixes #22 

The latest release of the [map-obj](https://github.com/sindresorhus/map-obj) library includes a fix for the incorrect handling of nested arrays.

Upgrading this dependency fixes the issue, but breaks support for Node 4.

## Changelog

### Changed

- Added test case for nested arrays

- Updated version of [map-obj](https://github.com/sindresorhus/map-obj) consumed

- Fixed linting error in source
![image](https://user-images.githubusercontent.com/21317379/45488156-5ec87280-b758-11e8-9b84-0d549c8c860e.png)

- Updated travis build to target Node 6 & lts

- `package.json` now requires node `>= 6`

### Removed

- Node 4 from travis build configuration

## Build & Test

✅ - [Build passing](https://travis-ci.org/JonShort/keys-to-camelcase/builds/427587732)
✅ - [Linting passing](https://travis-ci.org/JonShort/keys-to-camelcase/jobs/427587733#L1714)
✅ - [Tests passing](https://travis-ci.org/JonShort/keys-to-camelcase/jobs/427587733#L1714)

## Semver info

Change is:
[x] - Breaking
[  ] - Minor
[  ] - Patch

Breaking due to removal of Node 4 support