### PR TITLE
Add `pascalCase` option

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,8 +1,8 @@
 /* globals bench suite set */
 'use strict';
 const camelcaseKeysNpm = require('camelcase-keys');
-const camelcaseKeys = require('..');
 const fixture = require('./fixture');
+const camelcaseKeys = require('..');
 
 suite('camelcaseKeys', () => {
 	set('mintime', 1000);

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ camelcaseKeys([{'foo-bar': true}, {'bar-foo': false}]);
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true});
 //=> {fooBar: true, nested: {unicornRainbow: true}}
 
-// Convert an object to PascalCase notation
+// Convert object keys to pascal case
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true, pascalCase: true});
 //=> {FooBar: true, Nested: {UnicornRainbow: true}}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,13 @@ declare namespace camelcaseKeys {
 		@default []
 		*/
 		readonly exclude?: ReadonlyArray<string | RegExp>;
+
+		/**
+		Uppercase the first character as in 'bye-bye → ByeBye'
+
+		@default false
+		*/
+		readonly pascalCase?: boolean;
 	}
 }
 
@@ -36,6 +43,9 @@ camelcaseKeys([{'foo-bar': true}, {'bar-foo': false}]);
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true});
 //=> {fooBar: true, nested: {unicornRainbow: true}}
 
+// Convert an object to PascalCase notation
+camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true, pascalCase: true});
+//=> {FooBar: true, Nested: {UnicornRainbow: true}}
 
 import minimist = require('minimist');
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace camelcaseKeys {
 		readonly exclude?: ReadonlyArray<string | RegExp>;
 
 		/**
-		Uppercase the first character as in 'bye-bye → ByeBye'
+		Uppercase the first character as in `bye-bye` → `ByeBye`.
 
 		@default false
 		*/

--- a/index.js
+++ b/index.js
@@ -9,17 +9,18 @@ const cache = new QuickLru({maxSize: 100000});
 const camelCaseConvert = (input, options) => {
 	options = {
 		deep: false,
+		pascalCase: false,
 		...options
 	};
 
-	const {exclude} = options;
+	const {exclude, pascalCase} = options;
 
 	return mapObj(input, (key, value) => {
 		if (!(exclude && has(exclude, key))) {
 			if (cache.has(key)) {
 				key = cache.get(key);
 			} else {
-				const ret = camelCase(key);
+				const ret = camelCase(key, {pascalCase});
 
 				if (key.length < 100) { // Prevent abuse
 					cache.set(key, ret);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,5 +7,8 @@ expectType<{[key: string]: unknown}>(
 	camelcaseKeys({'foo-bar': true}, {deep: true})
 );
 expectType<{[key: string]: unknown}>(
+	camelcaseKeys({'foo-bar': true}, {deep: true, pascalCase: true})
+);
+expectType<{[key: string]: unknown}>(
 	camelcaseKeys({'foo-bar': true}, {exclude: ['foo', /bar/]})
 );

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,10 @@ camelcaseKeys([{'foo-bar': true}, {'bar-foo': false}]);
 
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true});
 //=> {fooBar: true, nested: {unicornRainbow: true}}
+
+// Convert an object to the PascalCase notation
+camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true, pascalCase: true});
+//=> {FooBar: true, Nested: {UnicornRainbow: true}}
 ```
 
 ```js
@@ -65,6 +69,13 @@ Type: `boolean`<br>
 Default: `false`
 
 Recurse nested objects and objects in arrays.
+
+##### pascalCase
+
+Type: `boolean`<br>
+Default: `false`
+
+Uppercase the first character as in 'bye-bye → ByeBye'.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ camelcaseKeys([{'foo-bar': true}, {'bar-foo': false}]);
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true});
 //=> {fooBar: true, nested: {unicornRainbow: true}}
 
-// Convert an object to the PascalCase notation
+// Convert object keys to pascal case
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true, pascalCase: true});
 //=> {FooBar: true, Nested: {UnicornRainbow: true}}
 ```
@@ -75,7 +75,7 @@ Recurse nested objects and objects in arrays.
 Type: `boolean`<br>
 Default: `false`
 
-Uppercase the first character as in 'bye-bye → ByeBye'.
+Uppercase the first character as in `bye-bye` → `ByeBye`.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -18,6 +18,18 @@ test('deep option', t => {
 	);
 });
 
+test('pascalCase option only', t => {
+	t.true(camelcaseKeys({'new-foo-bar': true}, {pascalCase: true}).NewFooBar);
+});
+
+test('pascalCase and deep options', t => {
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({p_foo_bar: true, p_obj: {p_two: false, p_arr: [{p_three_four: true}]}}, {deep: true, pascalCase: true}),
+		{PFooBar: true, PObj: {PTwo: false, PArr: [{PThreeFour: true}]}}
+	);
+});
+
 test('handles nested arrays', t => {
 	t.deepEqual(
 		// eslint-disable-next-line camelcase


### PR DESCRIPTION
This PR aims to fix  #30 

In this PR, I would like to merge the pascal case ("pascalCase") option to convert objects to PascalCase notation.

The first commit also fixes a lint error in [bench.js](bench/bench.js) (let me know if I should take that commit out).

Checklist:
- [x] Implementation in code
- [x] Added specific tests
- [x] Updated TypeScript definition files and relative test
- [x] Added the new option in the README.