### PR TITLE
Fix the TypeScript definition for TypeScript 3.5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,10 +59,10 @@ camelcaseKeys(argv);
 declare function camelcaseKeys(
 	input: ReadonlyArray<{[key: string]: any}>,
 	options?: camelcaseKeys.Options
-): Array<{[key: string]: unknown}>;
+): Array<{[key: string]: any}>;
 declare function camelcaseKeys(
 	input: {[key: string]: any},
 	options?: camelcaseKeys.Options
-): {[key: string]: unknown};
+): {[key: string]: any};
 
 export = camelcaseKeys;


### PR DESCRIPTION
Similar to #38 

The current definition doesn't allow accessing nested properties.
```javascript
const obj = { a: { a1: '1' } };
const ccObj = camelcaseKeys(obj, { deep: true });
console.log(ccObj.a.a1); // 'a1' does not exist on type 'unknown'.
```