### PR TITLE
Refactor: simplify variable declaration `stopPathsSet`

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const camelCaseConvert = (input, options) => {
 
 	const {exclude, pascalCase, stopPaths, deep} = options;
 
-	const stopPathsSet = stopPaths === undefined ? new Set() : new Set(stopPaths);
+	const stopPathsSet = new Set(stopPaths);
 
 	const makeMapper = parentPath => (key, value) => {
 		const path = parentPath === undefined ? key : `${parentPath}.${key}`;


### PR DESCRIPTION
When assigning a variable to stopPathsSet, it makes no sense to check for the existence of stopPaths, because
```js
console.log(new Set()); //=> Set {}
console.log(new Set([])); //=> Set {}
console.log(new Set(undefined)); //=> Set {}
console.log(new Set(null)); //=> Set {}
```