### PR TITLE
Fix the TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,12 +90,12 @@ camelcaseKeys(argv);
 //=> {_: [], fooBar: true}
 ```
 */
-declare function camelcaseKeys<T extends ReadonlyArray<{[key: string]: unknown}>>(
+declare function camelcaseKeys<T extends ReadonlyArray<{[key: string]: any}>>(
 	input: T,
 	options?: camelcaseKeys.Options,
 ): T;
 
-declare function camelcaseKeys<T extends {[key: string]: unknown}>(
+declare function camelcaseKeys<T extends {[key: string]: any}>(
 	input: T,
 	options?: camelcaseKeys.Options,
 ): T;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -34,7 +34,7 @@ interface SomeObject {
 }
 
 const someObj: SomeObject = {
-	someProperty: "hello",
+	someProperty: 'hello'
 };
 
 expectType<SomeObject>(camelcaseKeys(someObj));
@@ -45,7 +45,7 @@ type SomeTypeAlias = {
 }
 
 const objectWithTypeAlias = {
-	someProperty: "this should also work"
+	someProperty: 'this should also work'
 };
 
 expectType<SomeTypeAlias>(camelcaseKeys(objectWithTypeAlias));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -28,3 +28,25 @@ expectType<{[key in 'foo-bar']: true}>(
 expectType<{[key in 'foo-bar']: true}>(
 	camelcaseKeys({'foo-bar': true}, {stopPaths: ['foo']}),
 );
+
+interface SomeObject {
+	someProperty: string;
+}
+
+const someObj: SomeObject = {
+	someProperty: "hello",
+};
+
+expectType<SomeObject>(camelcaseKeys(someObj));
+expectType<SomeObject[]>(camelcaseKeys([someObj]));
+
+type SomeTypeAlias = {
+	someProperty: string;
+}
+
+const objectWithTypeAlias = {
+	someProperty: "this should also work"
+};
+
+expectType<SomeTypeAlias>(camelcaseKeys(objectWithTypeAlias));
+expectType<SomeTypeAlias[]>(camelcaseKeys([objectWithTypeAlias]));


### PR DESCRIPTION
motivation: this way the library is less restrictive and should be
easier to adopt to existing codebases.

We only really care about the keys in our objects being strings (as they
should be). Fixes #55 