### PR TITLE
Fix handling of array of non-objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const camelCaseConvert = (input, options) => {
 	if (typeof input !== 'object') {
 		return input;
 	}
+
 	options = {
 		deep: false,
 		pascalCase: false,

--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ const isObject = value =>
 	!(value instanceof Date);
 
 const camelCaseConvert = (input, options) => {
+	if (typeof input !== 'object') {
+		return input;
+	}
 	options = {
 		deep: false,
 		pascalCase: false,

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const isObject = value =>
 	!(value instanceof Date);
 
 const camelCaseConvert = (input, options) => {
-	if (typeof input !== 'object') {
+	if (!isObject(input)) {
 		return input;
 	}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,7 +13,7 @@ expectType<Array<{[key in 'foo-bar']: true}>>(camelcaseKeys([{'foo-bar': true}])
 
 expectType<Array<string>>(camelcaseKeys(['name 1', 'name 2']));
 
-expectType<Array<string>>(camelcaseKeys(['name 1', 'name 2'], { deep: true }));
+expectType<Array<string>>(camelcaseKeys(['name 1', 'name 2'], {deep: true}));
 
 expectType<{[key in 'foo-bar']: true}>(camelcaseKeys({'foo-bar': true}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,6 +11,10 @@ expectType<typeof fooBarArray>(camelFooBarArray);
 
 expectType<Array<{[key in 'foo-bar']: true}>>(camelcaseKeys([{'foo-bar': true}]));
 
+expectType<Array<string>>(camelcaseKeys(['name 1', 'name 2']));
+
+expectType<Array<string>>(camelcaseKeys(['name 1', 'name 2'], { deep: true }));
+
 expectType<{[key in 'foo-bar']: true}>(camelcaseKeys({'foo-bar': true}));
 
 expectType<{[key in 'foo-bar']: true}>(

--- a/test.js
+++ b/test.js
@@ -92,15 +92,17 @@ test('different pascalCase option values', t => {
 });
 
 test('return orginal array if they are not objects', t => {
+	const input = ['name 1', 'name 2'];
 	t.deepEqual(
-		camelcaseKeys(['name 1', 'name 2']),
-		['name 1', 'name 2']
+		camelcaseKeys(input),
+		input
 	);
 });
 
 test('return orginal array if they are not objects and deep options', t => {
+	const input = ['name 1', 'name 2'];
 	t.deepEqual(
-		camelcaseKeys(['name 1', 'name 2'], {deep: true}),
-		['name 1', 'name 2']
+		camelcaseKeys(input, {deep: true}),
+		input
 	);
 });

--- a/test.js
+++ b/test.js
@@ -90,3 +90,17 @@ test('different pascalCase option values', t => {
 		{pFooBar: true, pObj: {pTwo: false, pArr: [{pThreeFour: true}]}}
 	);
 });
+
+test('return orginal array if they are not objects', t => {
+	t.deepEqual(
+		camelcaseKeys(['name 1', 'name 2']),
+		['name 1', 'name 2']
+	);
+});
+
+test('return orginal array if they are not objects and deep options', t => {
+	t.deepEqual(
+		camelcaseKeys(['name 1', 'name 2'], {deep: true}),
+		['name 1', 'name 2']
+	);
+});


### PR DESCRIPTION
Example: `camelcaseKeys(['name 1', 'name2'], {
      deep: true,
    })`