### PR TITLE
fix: allow generic return values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,13 +90,16 @@ camelcaseKeys(argv);
 //=> {_: [], fooBar: true}
 ```
 */
-declare function camelcaseKeys<T extends ReadonlyArray<{[key: string]: any}>>(
-	input: T,
+
+type AnyKeyValuePair = {[key: string]: any}
+
+declare function camelcaseKeys<T extends ReadonlyArray<AnyKeyValuePair>>(
+	input: ReadonlyArray<AnyKeyValuePair>,
 	options?: camelcaseKeys.Options,
 ): T;
 
-declare function camelcaseKeys<T extends Record<string, any>>(
-	input: {[key: string]: any},
+declare function camelcaseKeys<T extends AnyKeyValuePair>(
+	input: AnyKeyValuePair,
 	options?: camelcaseKeys.Options,
 ): T;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,8 +95,8 @@ declare function camelcaseKeys<T extends ReadonlyArray<{[key: string]: any}>>(
 	options?: camelcaseKeys.Options,
 ): T;
 
-declare function camelcaseKeys<T extends {[key: string]: any}>(
-	input: T,
+declare function camelcaseKeys<T extends Record<string, any>>(
+	input: {[key: string]: any},
 	options?: camelcaseKeys.Options,
 ): T;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,24 @@
 import {expectType} from 'tsd';
 import camelcaseKeys = require('.');
 
-const fooBarObject = {'foo-bar': true};
-const camelFooBarObject = camelcaseKeys(fooBarObject);
-expectType<typeof fooBarObject>(camelFooBarObject);
+
+// Imagine our API responds with
+// data that is snake_cased.
+interface AnalyticsEventResponse {
+	path: string;
+	num_visits: number;
+}
+
+// On the client side, we might
+// extend the interface whereby
+// the keys are all camelized.
+interface AnalyticsEvent extends Pick<AnalyticsEventResponse, 'path'> {
+	numVisits: number;
+}
+
+const analyticsEventFromServer = {path: "/about", num_visits: 200};
+const camelCasedAnalyticsEvent = camelcaseKeys<AnalyticsEvent>(analyticsEventFromServer);
+expectType<AnalyticsEvent>(camelCasedAnalyticsEvent);
 
 const fooBarArray = [{'foo-bar': true}];
 const camelFooBarArray = camelcaseKeys(fooBarArray);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,9 +20,9 @@ const analyticsEventFromServer = {path: "/about", num_visits: 200};
 const camelCasedAnalyticsEvent = camelcaseKeys<AnalyticsEvent>(analyticsEventFromServer);
 expectType<AnalyticsEvent>(camelCasedAnalyticsEvent);
 
-const fooBarArray = [{'foo-bar': true}];
-const camelFooBarArray = camelcaseKeys(fooBarArray);
-expectType<typeof fooBarArray>(camelFooBarArray);
+const analyticsEventsArray = [{path: "/about", num_visits: 24}, {path:"/pricing", numVisits: 100}];
+const camelCasedEventsArray = camelcaseKeys<AnalyticsEvent[]>(analyticsEventsArray);
+expectType<AnalyticsEvent[]>(camelCasedEventsArray);
 
 expectType<Array<{[key in 'foo-bar']: true}>>(camelcaseKeys([{'foo-bar': true}]));
 


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/camelcase-keys/issues/60
cc: @OmgImAlexis + @trymbill

Previously, the `input` parameter's generic type prevented consumers from specifying what kind of object they expected _back_ from the `camelcaseKeys` function.

This PR drops this generic in favor of a more explicit `AnyKeyValuePair` type, and updates the test suite with some practical (IMO) use cases of the library.

**Example**
Let's assume you have an API that responds with data whose keys are snake cased.

```ts
interface AnalyticsEventResponse {
  path: string;
  num_visits: number;
}
```

On the client, you might want to convert `num_visits` to camel case, so you'd create another type/interface for that.

```ts
interface AnalyticsEvent extends Pick<AnalyticsEventResponse, 'path'> {
  numVisits: number;
}
```

Now, you can use this wonderful library to perform such a conversion, all the while maintaining type safety.

```ts
const analyticsEventFromServer = {path: "/about", num_visits: 200};
const camelCasedAnalyticsEvent = camelcaseKeys<AnalyticsEvent>(analyticsEventFromServer);
expectType<AnalyticsEvent>(camelCasedAnalyticsEvent); // ✅
```

LMK if there are any questions! There might be a better solution than the whole `AnyKeyValuePair` bit