### PR TITLE
Do not require options generic to be passed for the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ camelcaseKeys(argv);
 */
 declare function camelcaseKeys<
 	T extends Record<string, any> | readonly any[],
-	Options extends camelcaseKeys.Options
+	Options extends camelcaseKeys.Options = camelcaseKeys.Options
 >(
 	input: T,
 	options?: Options


### PR DESCRIPTION
I just want to override the first parameter, I'm not sure why it's forcing me to pass this Options generic, I assume it was unintendedly added on #72? @g-plane 