### PR TITLE
Use es6 module imports and default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
-const mapObj = require('map-obj');
-const camelCase = require('camelcase');
-const QuickLru = require('quick-lru');
+import mapObj from 'map-obj';
+import camelCase from 'camelcase';
+import QuickLru from 'quick-lru';
 
 const has = (array, key) => array.some(x => {
 	if (typeof x === 'string') {
@@ -68,7 +68,7 @@ const camelCaseConvert = (input, options) => {
 	return mapObj(input, makeMapper(undefined));
 };
 
-module.exports = (input, options) => {
+export default (input, options) => {
 	if (Array.isArray(input)) {
 		return Object.keys(input).map(key => camelCaseConvert(input[key], options));
 	}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	"dependencies": {
 		"camelcase": "^6.2.0",
 		"map-obj": "^4.1.0",
-		"quick-lru": "^5.1.1",
+		"quick-lru": "^6.0.0",
 		"type-fest": "^1.2.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Changed to es6 imports and export with `export default`. 

Also uses a newer version of QuickLRU which does the same.

This allows the package to work in es6 projects.