### PR TITLE
Fix `CamelCaseKeys` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,16 +66,14 @@ type CamelCaseKeys<
 			]
 				? T[P]
 				: [Deep] extends [true]
-					? T[P] extends Record<string, any>
-						? CamelCaseKeys<
-						T[P],
-						Deep,
-						IsPascalCase,
-						Exclude,
-						StopPaths,
-						AppendPath<Path, P>
-						>
-						: T[P]
+					? CamelCaseKeys<
+					T[P],
+					Deep,
+					IsPascalCase,
+					Exclude,
+					StopPaths,
+					AppendPath<Path, P>
+					>
 					: T[P];
 		}
 		// Return anything else as-is.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -36,6 +36,26 @@ expectType<{fooBar: {fooBar: {fooBar: boolean}}}>(
 	)
 );
 
+interface ObjectOrUndefined {
+	foo_bar: {
+		foo_bar: {
+			foo_bar: boolean;
+		} | undefined;
+	};
+}
+
+const objectOrUndefined: ObjectOrUndefined = {
+	foo_bar: {
+		foo_bar: {
+			foo_bar: true
+		}
+	}
+};
+
+expectType<{ fooBar: { fooBar: { fooBar: boolean } | undefined } }>(
+	camelcaseKeys(objectOrUndefined, {deep: true})
+);
+
 expectType<{FooBar: boolean}>(
 	camelcaseKeys({'foo-bar': true}, {pascalCase: true})
 );

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -52,7 +52,7 @@ const objectOrUndefined: ObjectOrUndefined = {
 	}
 };
 
-expectType<{ fooBar: { fooBar: { fooBar: boolean } | undefined } }>(
+expectType<{fooBar: {fooBar: {fooBar: boolean} | undefined}}>(
 	camelcaseKeys(objectOrUndefined, {deep: true})
 );
 


### PR DESCRIPTION
The type of camelCaseKeys is incorrect and has been fixed.
When the type is object or undefined, the hierarchy after that remains in snakeCase.

```
interface ObjectOrUndefined {
	foo_bar: {
		foo_bar: {
			foo_bar: boolean;
		} | undefined;
	};
}

const objectOrUndefined: ObjectOrUndefined = {
	foo_bar: {
		foo_bar: {
			foo_bar: true
		}
	}
};

expectType<{ fooBar: { fooBar: { fooBar: boolean } | undefined } }>(
	camelcaseKeys(objectOrUndefined, {deep: true})
);
```

As a result of the test, the following error occurred.

```
Argument of type { fooBar: { fooBar: { foo_bar: boolean; } | undefined; }; } is not assignable to parameter of type { fooBar: { fooBar: { fooBar: boolean; } | undefined; }; }.
  The types of fooBar.fooBar are incompatible between these types.
    Type { foo_bar: boolean; } | undefined is not assignable to type { fooBar: boolean; } | undefined.
      Property fooBar is missing in type { foo_bar: boolean; } but required in type { fooBar: boolean; }. 
```

With this fix, the conversion will be correct as follows
```
{ fooBar: { fooBar: { fooBar: boolean } | undefined } }
```