### PR TITLE
Exclude children at the given keys from being camel-cased

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ declare namespace camelcaseKeys {
 		readonly stopPaths?: readonly string[];
 
 		/**
-		Exclude children at the given object key from being camel-cased.
+		Exclude children at the given object keys from being camel-cased. This will match any object key with the given names at any nesting level.
 
 		If this option can be statically determined, it's recommended to add `as const` to it.
 
@@ -157,7 +157,7 @@ declare namespace camelcaseKeys {
 			deep: true,
 			stopKeys: [
 				'c_e'
-			]
+			] as const
 		}),
 		// {
 		// 	aB: 1,

--- a/index.js
+++ b/index.js
@@ -33,15 +33,16 @@ const camelCaseConvert = (input, options) => {
 		...options
 	};
 
-	const {exclude, pascalCase, stopPaths, deep} = options;
+	const {exclude, pascalCase, stopPaths, stopKeys, deep} = options;
 
 	const stopPathsSet = new Set(stopPaths);
+	const stopKeysSet = new Set(stopKeys);
 
 	const makeMapper = parentPath => (key, value) => {
 		if (deep && isObject(value)) {
 			const path = parentPath === undefined ? key : `${parentPath}.${key}`;
 
-			if (!stopPathsSet.has(path)) {
+			if (!stopPathsSet.has(path) && !stopKeysSet.has(key)) {
 				value = mapObj(value, makeMapper(path));
 			}
 		}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -95,6 +95,16 @@ expectType<{topLevel: {fooBar: {'bar-baz': boolean}}; fooFoo: boolean}>(
 	)
 );
 
+expectType<{fooBar: boolean}>(
+	camelcaseKeys({'foo-bar': true}, {stopKeys: ['foo']})
+);
+expectType<{topLevel: {fooBar: {'bar-baz': boolean}}; fooFoo: boolean}>(
+	camelcaseKeys(
+		{'top-level': {'foo-bar': {'bar-baz': true}}, 'foo-foo': true},
+		{deep: true, stopKeys: ['foo-bar'] as const}
+	)
+);
+
 expectAssignable<Record<string, string>>(
 	camelcaseKeys({} as Record<string, string>)
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "camelcase-keys",
-	"version": "7.0.2",
+	"version": "7.1.0",
 	"description": "Convert object keys to camel case",
 	"license": "MIT",
 	"repository": "sindresorhus/camelcase-keys",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "camelcase-keys",
-	"version": "7.1.0",
+	"version": "7.0.2",
 	"description": "Convert object keys to camel case",
 	"license": "MIT",
 	"repository": "sindresorhus/camelcase-keys",

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ camelcaseKeys({
 Type: `string[]`\
 Default: `[]`
 
-Exclude children at the given object keys from being camel-cased.
+Exclude children at the given object keys from being camel-cased. This will match any object key with the given names at any nesting level.
 
 ```js
 camelcaseKeys({

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,9 @@ camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true});
 camelcaseKeys({a_b: 1, a_c: {c_d: 1, c_e: {e_f: 1}}}, {deep: true, stopPaths: ['a_c.c_e']}),
 //=> {aB: 1, aC: {cD: 1, cE: {e_f: 1}}}
 
+camelcaseKeys({a_b: 1, a_c: {c_d: 1, c_e: {e_f: 1}}}, {deep: true, stopKeys: ['c_e']}),
+//=> {aB: 1, aC: {cD: 1, cE: {e_f: 1}}}
+
 // Convert object keys to pascal case
 camelcaseKeys({'foo-bar': true, nested: {unicorn_rainbow: true}}, {deep: true, pascalCase: true});
 //=> {FooBar: true, Nested: {UnicornRainbow: true}}
@@ -93,6 +96,49 @@ camelcaseKeys({
 		cE: {
 			e_f: 1
 		}
+	}
+}
+*/
+```
+
+##### stopKeys
+
+Type: `string[]`\
+Default: `[]`
+
+Exclude children at the given object keys from being camel-cased.
+
+```js
+camelcaseKeys({
+	a_b: 1,
+	a_c: {
+		c_d: 1,
+		foo_bar: {
+			foo_bar_a: 1
+		}
+	},
+	a_d: 1,
+	foo_bar: {
+		foo_bar_b: 1
+	}
+}, {
+	deep: true,
+	stopKeys: [
+		'foo_bar'
+	]
+}),
+/*
+{
+	aB: 1,
+	aC: {
+		cD: 1,
+		fooBar: {
+			foo_bar_a: 1
+		}
+	},
+	aD: 1,
+	fooBar: {
+		foo_bar_b: 1
 	}
 }
 */

--- a/test.js
+++ b/test.js
@@ -51,6 +51,36 @@ test('stopPaths option', t => {
 	);
 });
 
+test('stopKeys option', t => {
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({foo_bar: true, obj: {one_two: false, arr: [{three_four: true}]}}, {deep: true, stopKeys: ['obj']}),
+		// eslint-disable-next-line camelcase
+		{fooBar: true, obj: {one_two: false, arr: [{three_four: true}]}}
+	);
+
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({foo_bar: true, obj: {one_two: false, arr: [{three_four: true}]}}, {deep: true, stopKeys: ['arr']}),
+		// eslint-disable-next-line camelcase
+		{fooBar: true, obj: {oneTwo: false, arr: [{three_four: true}]}}
+	);
+
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({foo_bar: [[{a_b: 1}, {b_c: 2}, {c_d: 3, c_e: {foo_bar: 1}}]]}, {deep: true, stopKeys: ['c_e']}),
+		// eslint-disable-next-line camelcase
+		{fooBar: [[{aB: 1}, {bC: 2}, {cD: 3, cE: {foo_bar: 1}}]]}
+	);
+
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({a_b: {b_c: 1, obj: {foo_bar: 1}}, a_c: {c_d: {obj: {foo_bar: 1}}}, obj: {foo_bar: 1}}, {deep: true, stopKeys: ['obj']}),
+		// eslint-disable-next-line camelcase
+		{aB: {bC: 1, obj: {foo_bar: 1}}, aC: {cD: {obj: {foo_bar: 1}}}, obj: {foo_bar: 1}}
+	);
+});
+
 test('pascalCase option only', t => {
 	t.true(camelcaseKeys({'new-foo-bar': true}, {pascalCase: true}).NewFooBar);
 });


### PR DESCRIPTION
Hi,

I propose a new feature, the `stopKeys: string[]` option.

**What does the option do?**
Similarly to the `stopPaths` option, the `stopKeys` option will exclude all children meeting the specified criteria.
`stopKeys` allows to define a list of keys that should be detected when parsing the object. If one of the key is found, the parser stops and does not convert the children.


**Why do we need this option?**
This feature is helpful when we need to convert the keys of an object but want to exclude some keys under a specific parent. In most cases `stopPaths` can probably answer the need, however when we do not have full knowledge and control over the structure of the object to convert, then it can be difficult to create and maintain the correct paths.
