### PR TITLE
Improve type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,13 +45,16 @@ export type CamelCaseKeys<
 > = T extends readonly any[]
 	// Handle arrays or tuples.
 	? {
-		[P in keyof T]: CamelCaseKeys<
-		T[P],
-		Deep,
-		IsPascalCase,
-		Exclude,
-		StopPaths
-		>;
+		// eslint-disable-next-line @typescript-eslint/ban-types
+		[P in keyof T]: {} extends CamelCaseKeys<T[P]>
+			? T[P]
+			: CamelCaseKeys<
+			T[P],
+			Deep,
+			IsPascalCase,
+			Exclude,
+			StopPaths
+			>;
 	}
 	: T extends Record<string, any>
 		// Handle objects.
@@ -64,16 +67,19 @@ export type CamelCaseKeys<
 				true,
 			]
 				? T[P]
-				: [Deep] extends [true]
-					? CamelCaseKeys<
-					T[P],
-					Deep,
-					IsPascalCase,
-					Exclude,
-					StopPaths,
-					AppendPath<Path, P & string>
-					>
-					: T[P];
+				// eslint-disable-next-line @typescript-eslint/ban-types
+				: {} extends CamelCaseKeys<T[P]>
+					? T[P]
+					: [Deep] extends [true]
+						? CamelCaseKeys<
+						T[P],
+						Deep,
+						IsPascalCase,
+						Exclude,
+						StopPaths,
+						AppendPath<Path, P & string>
+						>
+						: T[P];
 		}
 		// Return anything else as-is.
 		: T;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -356,21 +356,21 @@ expectType<{
 	recordBar: {foo: string};
 	promiseBaz: Promise<unknown>;
 }>(camelcaseKeys({
-			func_foo: () => 'foo',
-			record_bar: {foo: 'bar'},
-			promise_baz: new Promise(resolve => {
-				resolve(true);
-			}),
-		}));
+	func_foo: () => 'foo',
+	record_bar: {foo: 'bar'},
+	promise_baz: new Promise(resolve => {
+		resolve(true);
+	}),
+}));
 
 expectType<[
 	() => 'foo',
 	{foo: string},
 	Promise<unknown>,
 ]>(camelcaseKeys([
-			() => 'foo',
-			{foo: 'bar'},
-			new Promise(resolve => {
-				resolve(true);
-			}),
-		]));
+	() => 'foo',
+	{foo: 'bar'},
+	new Promise(resolve => {
+		resolve(true);
+	}),
+]));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -350,3 +350,27 @@ expectNotType<InvalidConvertedExcludeObjectDataType>(
 		exclude,
 	}),
 );
+
+expectType<{
+	funcFoo: () => 'foo';
+	recordBar: {foo: string};
+	promiseBaz: Promise<unknown>;
+}>(camelcaseKeys({
+			func_foo: () => 'foo',
+			record_bar: {foo: 'bar'},
+			promise_baz: new Promise(resolve => {
+				resolve(true);
+			}),
+		}));
+
+expectType<[
+	() => 'foo',
+	{foo: string},
+	Promise<unknown>,
+]>(camelcaseKeys([
+			() => 'foo',
+			{foo: 'bar'},
+			new Promise(resolve => {
+				resolve(true);
+			}),
+		]));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -355,22 +355,26 @@ expectType<{
 	funcFoo: () => 'foo';
 	recordBar: {foo: string};
 	promiseBaz: Promise<unknown>;
-}>(camelcaseKeys({
-	func_foo: () => 'foo',
-	record_bar: {foo: 'bar'},
-	promise_baz: new Promise(resolve => {
-		resolve(true);
+}>(
+	camelcaseKeys({
+		func_foo: () => 'foo',
+		record_bar: {foo: 'bar'},
+		promise_baz: new Promise(resolve => {
+			resolve(true);
+		}),
 	}),
-}));
+);
 
 expectType<[
 	() => 'foo',
 	{foo: string},
 	Promise<unknown>,
-]>(camelcaseKeys([
-	() => 'foo',
-	{foo: 'bar'},
-	new Promise(resolve => {
-		resolve(true);
-	}),
-]));
+]>(
+	camelcaseKeys([
+		() => 'foo',
+		{foo: 'bar'},
+		new Promise(resolve => {
+			resolve(true);
+		}),
+	]),
+);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/indent */
 import {expectType, expectAssignable, expectNotType} from 'tsd';
 import camelcaseKeys, {type CamelCaseKeys} from './index.js';
 


### PR DESCRIPTION
# Description
Some kind of values (such as functions, records, or promises) are incorrectly inferred as `{}` when deep option is enabled. It is because CamelCaseKeys accepts `Record<string, any>` and so it admits some non-record-like types such as functions while it infer them as `{}`. For example, `() => number` extends `Record<string, any>` and `CamelCaseKeys<() => number>` is `{}`. 

[Reproduction Link](https://codesandbox.io/s/mystifying-shockley-z9mz9l?file=/src/index.ts)

This cause some trouble when you use types like FileList since many of its values would be inferred as `{}`. I fixed the issue by adding a condition for whether `CamelCaseKeys<T[P]>` is too wide or not.