### PR TITLE
Prevent webpack loader errors from _ number separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const has = (array, key) => array.some(element => {
 	return element.test(key);
 });
 
-const cache = new QuickLru({maxSize: 100_000});
+const cache = new QuickLru({maxSize: 100000});
 
 // Reproduces behavior from `map-obj`.
 const isObject = value =>


### PR DESCRIPTION
I'm trying to build this, but it says:

```
 error  in ./node_modules/camelcase-keys/index.js

Module parse failed: Identifier directly after number (15:40)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| });
| 
> const cache = new QuickLru({maxSize: 100_000});
| 
| // Reproduces behavior from `map-obj`.
```

which is resolved by adding this change. No idea why, but I figured others might have this problem for some reason and it's easily fixed.