### PR TITLE
Upgrade to current map-obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"camelcase": "^7.0.0",
-		"map-obj": "^4.3.0",
+		"map-obj": "^5.0.2",
 		"quick-lru": "^6.1.1",
 		"type-fest": "^2.13.0"
 	},


### PR DESCRIPTION
Currently: 
While using camelcase-keys, im getting a nested error from the built library.
```
Creating an optimized production build...
Failed to compile.

Attempted import error: 'map-obj' does not contain a default export (imported as 'mapObject').
```

After digging, the library currently assumes `map-obj` is exporting a default function, but the `4.3.0` version that was pinned does not export the called function as a default. The current `5.0.2` version of `map-obj` does, however. I assume no other breaking changes took place besides how the function is exported, so the only fix required was to bump the dependency.

It does however seem that tests are failing. I could use some assistance in next steps to resolve this issue.