### PR TITLE
Prevent webpack loader errors from _ number separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const has = (array, key) => array.some(element => {
 	return element.test(key);
 });
 
-const cache = new QuickLru({maxSize: 100_000});
+const cache = new QuickLru({maxSize: 100000});
 
 // Reproduces behavior from `map-obj`.
 const isObject = value =>


### PR DESCRIPTION
https://github.com/sindresorhus/camelcase-keys/pull/101 cc. @nickdnk
In react native, an error occurred during build, so version 8 cannot be used.

React native users have to use v7 until this code fixed.
I suggest modifying this code for v8 support.

```sh
error node_modules/camelcase-keys/index.js: Unexpected token name «_000», expected punc «,» in file node_modules/camelcase-keys/index.js at 19:16.
Error: Unexpected token name «_000», expected punc «,» in file node_modules/camelcase-keys/index.js at 19:16
    at minifyCode (node_modules/metro-transform-worker/src/index.js:99:13)
    at transformJS (node_modules/metro-transform-worker/src/index.js:320:28)
    at transformJSWithBabel (node_modules/metro-transform-worker/src/index.js:411:16)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.transform (node_modules/metro-transform-worker/src/index.js:572:12)
info Run CLI with --verbose flag for more details.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```