### PR TITLE
fix: default value setting to correctly resolve function return types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ Return a default type if input type is nil.
 @template T - Input type.
 @template U - Default type.
 */
-type WithDefault<T, U extends T> = T extends undefined | void | null ? U : T; // eslint-disable-line @typescript-eslint/ban-types
+type WithDefault<T, U> = T extends undefined | void | null ? U : T; // eslint-disable-line @typescript-eslint/ban-types
 
 // TODO: Replace this with https://github.com/sindresorhus/type-fest/blob/main/source/includes.d.ts
 /**
@@ -237,9 +237,9 @@ export default function camelcaseKeys<
 	options?: OptionsType
 ): CamelCaseKeys<
 T,
-WithDefault<OptionsType['deep'], false>,
-WithDefault<OptionsType['pascalCase'], false>,
-WithDefault<OptionsType['preserveConsecutiveUppercase'], false>,
-WithDefault<OptionsType['exclude'], EmptyTuple>,
-WithDefault<OptionsType['stopPaths'], EmptyTuple>
+WithDefault<'deep' extends keyof OptionsType ? OptionsType['deep'] : undefined, false>,
+WithDefault<'pascalCase' extends keyof OptionsType ? OptionsType['pascalCase'] : undefined, false>,
+WithDefault<'preserveConsecutiveUppercase' extends keyof OptionsType ? OptionsType['preserveConsecutiveUppercase'] : undefined, false>,
+WithDefault<'exclude' extends keyof OptionsType ? OptionsType['exclude'] : undefined, EmptyTuple>,
+WithDefault<'stopPaths' extends keyof OptionsType ? OptionsType['stopPaths'] : undefined, EmptyTuple>
 >;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -453,3 +453,21 @@ expectType<[
 		}),
 	]),
 );
+
+// Test for function with inferred type
+// eslint-disable-next-line @typescript-eslint/comma-dangle
+function camelcaseKeysDeep<
+	T extends Record<string, unknown> | readonly unknown[]
+>(response: T): CamelCaseKeys<T, true> {
+	return camelcaseKeys(response, {deep: true});
+}
+
+// eslint-disable-next-line @typescript-eslint/comma-dangle
+function camelcaseKeysPascalCase<
+	T extends Record<string, unknown> | readonly unknown[]
+>(response: T): CamelCaseKeys<T, false, true> {
+	return camelcaseKeys(response, {pascalCase: true});
+}
+
+expectType<{fooBar: {hogeHoge: string}}>(camelcaseKeysDeep({foo_bar: {hoge_hoge: 'hoge_hoge'}}));
+expectType<{FooBar: string}>(camelcaseKeysPascalCase({foo_bar: 'foo_bar'}));


### PR DESCRIPTION
This ought to fix https://github.com/sindresorhus/camelcase-keys/issues/116.

The problem lies in the generic type `OptionsType`.
For example, if `pascalCase` is not included in the options, the following type definition would result in the type being `unknow`.
```ts
OptionsType['pascalCase']; // unknown
```

Therefore, the type would be `CamelCaseKeys<T, true, unknown, unknown, unknown, "">` as in the issue, resulting in a compile error.

With this fix, i change the type to be undefined when there is no key in the options, so the type `WithDefault` works correctly and the type of the default value part is the default value for each.

Specifically, it becomes `CamelCaseKeys<T, true>` when the options are as follows.

```ts
camelcaseKeys(response, {deep: true}); // CamelCaseKeys<T, true>
```

※The above without abbreviation would be `CamelCaseKeys<T, true, false, false, [], [], ''>`.
