### PR TITLE
fix: not recursively camelCase keys in nested objects when using union with null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,8 @@ import type {CamelCase, PascalCase} from 'type-fest';
 // eslint-disable-next-line @typescript-eslint/ban-types
 type EmptyTuple = [];
 
-type ObjectOptional = Record<string, unknown> | undefined;
+// Allow union (ex. optional property(undefined), null)
+type ObjectUnion = Record<string, unknown> | unknown;
 
 /**
 Return a default type if input type is nil.
@@ -38,7 +39,7 @@ type AppendPath<S extends string, Last extends string> = S extends ''
 Convert keys of an object to camelcase strings.
 */
 export type CamelCaseKeys<
-	T extends ObjectOptional | readonly any[],
+	T extends ObjectUnion | readonly any[],
 	Deep extends boolean = false,
 	IsPascalCase extends boolean = false,
 	PreserveConsecutiveUppercase extends boolean = false,
@@ -71,7 +72,7 @@ export type CamelCaseKeys<
 			]
 				? T[P]
 				: [Deep] extends [true]
-					? T[P] extends ObjectOptional | readonly any[]
+					? T[P] extends ObjectUnion | readonly any[]
 						? CamelCaseKeys<
 						T[P],
 						Deep,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import type {CamelCase, PascalCase} from 'type-fest';
 // eslint-disable-next-line @typescript-eslint/ban-types
 type EmptyTuple = [];
 
-// Allow union (ex. optional property(undefined), null)
+// Allow union with, for example, `undefined` and `null`.
 type ObjectUnion = Record<string, unknown> | unknown;
 
 /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -471,3 +471,16 @@ function camelcaseKeysPascalCase<
 
 expectType<{fooBar: {hogeHoge: string}}>(camelcaseKeysDeep({foo_bar: {hoge_hoge: 'hoge_hoge'}}));
 expectType<{FooBar: string}>(camelcaseKeysPascalCase({foo_bar: 'foo_bar'}));
+
+// Test for union type
+// eslint-disable-next-line @typescript-eslint/ban-types
+const objectCamelcased: CamelCaseKeys<{foo_bar: {foo_prop: string} | null}, true>
+	= camelcaseKeys({foo_bar: {foo_prop: 'foo_props'}}, {deep: true});
+// eslint-disable-next-line @typescript-eslint/ban-types
+const nullCamelcased: CamelCaseKeys<{foo_bar: {foo_prop: string} | null}, true>
+	= camelcaseKeys({foo_bar: null}, {deep: true});
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+expectType<{fooBar: {fooProp: string} | null}>(objectCamelcased);
+// eslint-disable-next-line @typescript-eslint/ban-types
+expectType<{fooBar: {fooProp: string} | null}>(nullCamelcased);


### PR DESCRIPTION
This ought to fix https://github.com/sindresorhus/camelcase-keys/issues/118.

The bug in the issue is due to the fact that the `type ObjectOptional` assumed only undefined (optional property), so I have fixed that part.

#### Supplemental information on testing

Since the `type CamelCaseKeys` cannot be tested as is, it is tested by specifying the `type CamelCaseKeys` for the variable after conversion with `camelcaseKeys`.

The test for `index.d.ts` before the modification failed as follows, but after the modification, the test passes because the union part works correctly.

![image](https://github.com/sindresorhus/camelcase-keys/assets/79501292/d8fe9ad4-e046-46c7-9487-fffa77218153)
