### PR TITLE
fix: update type for input and optiopns and update README

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,17 +39,17 @@ type AppendPath<S extends string, Last extends string> = S extends ''
 Convert keys of an object to camelcase strings.
 */
 export type CamelCaseKeys<
-	T extends ObjectUnion | readonly any[],
+	T extends ObjectUnion | ReadonlyArray<Record<string, unknown>>,
 	Deep extends boolean = false,
 	IsPascalCase extends boolean = false,
 	PreserveConsecutiveUppercase extends boolean = false,
 	Exclude extends readonly unknown[] = EmptyTuple,
 	StopPaths extends readonly string[] = EmptyTuple,
 	Path extends string = '',
-> = T extends readonly any[]
+> = T extends ReadonlyArray<Record<string, unknown>>
 	// Handle arrays or tuples.
 	? {
-		[P in keyof T]: T[P] extends Record<string, unknown> | readonly any[]
+		[P in keyof T]: T[P] extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>
 			? CamelCaseKeys<
 			T[P],
 			Deep,
@@ -72,7 +72,7 @@ export type CamelCaseKeys<
 			]
 				? T[P]
 				: [Deep] extends [true]
-					? T[P] extends ObjectUnion | readonly any[]
+					? T[P] extends ObjectUnion | ReadonlyArray<Record<string, unknown>>
 						? CamelCaseKeys<
 						T[P],
 						Deep,

--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ camelcaseKeys(commandLineArguments);
 ```
 */
 export default function camelcaseKeys<
-	T extends Record<string, unknown> | readonly any[],
+	T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>,
 	OptionsType extends Options = Options,
 >(
 	input: T,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,10 +12,6 @@ expectType<Array<{fooBar: boolean}>>(camelFooBarArray);
 
 expectType<Array<{fooBar: boolean}>>(camelcaseKeys([{'foo-bar': true}]));
 
-expectType<string[]>(camelcaseKeys(['name 1', 'name 2']));
-
-expectType<string[]>(camelcaseKeys(['name 1', 'name 2'], {deep: true}));
-
 expectType<readonly [{readonly fooBar: true}, {readonly fooBaz: true}]>(
 	camelcaseKeys([{'foo-bar': true}, {'foo-baz': true}] as const),
 );
@@ -440,31 +436,17 @@ expectType<{
 	}),
 );
 
-expectType<[
-	() => 'foo',
-	{foo: string},
-	Promise<unknown>,
-]>(
-	camelcaseKeys([
-		() => 'foo',
-		{foo: 'bar'},
-		new Promise(resolve => {
-			resolve(true);
-		}),
-	]),
-);
-
 // Test for function with inferred type
 // eslint-disable-next-line @typescript-eslint/comma-dangle
 function camelcaseKeysDeep<
-	T extends Record<string, unknown> | readonly unknown[]
+	T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>
 >(response: T): CamelCaseKeys<T, true> {
 	return camelcaseKeys(response, {deep: true});
 }
 
 // eslint-disable-next-line @typescript-eslint/comma-dangle
 function camelcaseKeysPascalCase<
-	T extends Record<string, unknown> | readonly unknown[]
+	T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>
 >(response: T): CamelCaseKeys<T, false, true> {
 	return camelcaseKeys(response, {pascalCase: true});
 }

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ camelcaseKeys(commandLineArguments);
 
 #### input
 
-Type: `Record<string, unknown> | any[]`
+Type: `Record<string, unknown> | Record<string, unknown>[]`
 
 An `Record<string, unknown>` or array of any to camel-case.
 

--- a/readme.md
+++ b/readme.md
@@ -39,13 +39,13 @@ camelcaseKeys(commandLineArguments);
 
 #### input
 
-Type: `object | object[]`
+Type: `Record<string, unknown> | any[]`
 
-An object or array of objects to camel-case.
+An `Record<string, unknown>` or array of any to camel-case.
 
 #### options
 
-Type: `object`
+Type: `Options`
 
 ##### exclude
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ An `Record<string, unknown>` or array of `Record<string, unknown>` to camel-case
 
 #### options
 
-Type: `Options`
+Type: `object`
 
 ##### exclude
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ camelcaseKeys(commandLineArguments);
 
 Type: `Record<string, unknown> | ReadonlyArray<Record<string, unknown>>`
 
-An `Record<string, unknown>` or array of `Record<string, unknown>` to camel-case.
+A plain object or array of plain objects to camel-case.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,9 @@ camelcaseKeys(commandLineArguments);
 
 #### input
 
-Type: `Record<string, unknown> | Record<string, unknown>[]`
+Type: `Record<string, unknown> | ReadonlyArray<Record<string, unknown>>`
 
-An `Record<string, unknown>` or array of any to camel-case.
+An `Record<string, unknown>` or array of `Record<string, unknown>` to camel-case.
 
 #### options
 


### PR DESCRIPTION
This resolves the issue https://github.com/sindresorhus/camelcase-keys/issues/121.

I am updating the README to match the TypeScript type definitions.

**Note** Regarding the existing type definitions, I don't see any problem with the existing type definitions. This is because the `map-obj` functionality that `camelcase-keys` relies on appears to be intended to convert key-value record types, not object types.