### PR TITLE
fix: do not deep convert buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import mapObject from 'map-obj';
 import camelCase from 'camelcase';
 import QuickLru from 'quick-lru';
@@ -19,10 +18,7 @@ const cache = new QuickLru({maxSize: 100_000});
 const isObject = value =>
 	typeof value === 'object'
 		&& value !== null
-		&& !(value instanceof RegExp)
-		&& !(value instanceof Error)
-		&& !(value instanceof Date)
-		&& !(value instanceof Buffer);
+		&& (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype);
 
 const transform = (input, options = {}) => {
 	if (!isObject(input)) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import {Buffer} from 'node:buffer';
 import mapObject from 'map-obj';
 import camelCase from 'camelcase';
 import QuickLru from 'quick-lru';
@@ -20,7 +21,8 @@ const isObject = value =>
 		&& value !== null
 		&& !(value instanceof RegExp)
 		&& !(value instanceof Error)
-		&& !(value instanceof Date);
+		&& !(value instanceof Date)
+		&& !(value instanceof Buffer);
 
 const transform = (input, options = {}) => {
 	if (!isObject(input)) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import {promisify} from 'node:util';
 import {execFile} from 'node:child_process';
+import {Buffer} from 'node:buffer';
 import test from 'ava';
 import camelcaseKeys from './index.js';
 
@@ -134,6 +135,11 @@ test('use locale independent camel-case transformation', async t => {
 		await runInTestProcess([input], {env: {...process.env, LC_ALL: 'tr'}}),
 		{userId: 123},
 	);
+});
+
+test('do not deep convert buffer', t => {
+	const input = {foo: Buffer.from('foo')};
+	t.true(camelcaseKeys(input, {deep: true}).foo instanceof Buffer);
 });
 
 /**

--- a/test.js
+++ b/test.js
@@ -137,9 +137,9 @@ test('use locale independent camel-case transformation', async t => {
 	);
 });
 
-test('do not deep convert buffer', t => {
+test('do not deep convert data', t => {
 	const input = {foo: Buffer.from('foo')};
-	t.true(camelcaseKeys(input, {deep: true}).foo instanceof Buffer);
+	t.true(camelcaseKeys(input, {deep: true}).foo instanceof Uint8Array);
 });
 
 /**


### PR DESCRIPTION
Buffers are traversed recursively but they shouldn't. I think it's also relevant for other related packages.