### PR TITLE
Add options `excludeChildren`, `overrides`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,38 @@ export type Options = {
 	readonly exclude?: ReadonlyArray<string | RegExp>;
 
 	/**
+	 * Exclude children of the given keys from being camel-cased.
+	 * @default []
+	 * @example
+	 * ```
+	 * decamelizeKeys({
+	 * 		a_b: 1,
+	 *		a_c: {
+	 *			c_d: 1,
+	 *			c_e: {
+	 *				e_f: 1
+	 *			}
+	 *		}
+	 *	}, {
+	 *    deep: true,
+	 *    excludeChildren: [
+	 *    	'a_c'
+	 *    ]
+	 * })
+	 *
+	 * // {
+	 * // 	aB: 1,
+	 * // 	aC: {
+	 * // 		c_d: 1,
+	 * // 		c_e: {
+	 * // 			eF: 1
+	 * // 		}
+	 * // 	}
+	 * // }
+	 */
+	readonly excludeChildren?: ReadonlyArray<string | RegExp>;
+
+	/**
 	Recurse nested objects and objects in arrays.
 
 	@default false
@@ -198,6 +230,24 @@ export type Options = {
 	```
 	*/
 	readonly stopPaths?: readonly string[];
+
+	/**
+	 * A list of matching keys that will be manually overridden with the provided value.
+	 * @default []
+	 * @example
+	 * ```
+	 * camelcaseKeys(
+	 * 	 {foo_bar: true, nested: {unicorn_rainbow: true}},
+	 * 	 {
+	 * 	   overrides: [
+	 * 		   ['foo_bar', 'foo_baz'],
+	 * 		 ]
+	 * 	 }
+	 * )
+	 *
+	 * //=> {'foo_baz': true, nested: {'unicorn_rainbow': true}}
+	 */
+	readonly overrides?: ReadonlyArray<[string | RegExp, string]>;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,8 @@ export type CamelCaseKeys<
 	PreserveConsecutiveUppercase extends boolean = false,
 	Exclude extends readonly unknown[] = EmptyTuple,
 	StopPaths extends readonly string[] = EmptyTuple,
+	ExcludeChildren extends readonly unknown[] = EmptyTuple,
+	Overrides extends ReadonlyArray<readonly [string | RegExp, string]> = EmptyTuple,
 	Path extends string = '',
 > = T extends ReadonlyArray<Record<string, unknown>>
 	// Handle arrays or tuples.
@@ -56,7 +58,9 @@ export type CamelCaseKeys<
 			IsPascalCase,
 			PreserveConsecutiveUppercase,
 			Exclude,
-			StopPaths
+			StopPaths,
+			ExcludeChildren,
+			Overrides
 			>
 			: T[P];
 	}
@@ -80,6 +84,8 @@ export type CamelCaseKeys<
 						PreserveConsecutiveUppercase,
 						Exclude,
 						StopPaths,
+						ExcludeChildren,
+						Overrides,
 						AppendPath<Path, P & string>
 						>
 						: T[P]
@@ -292,5 +298,7 @@ WithDefault<'deep' extends keyof OptionsType ? OptionsType['deep'] : undefined, 
 WithDefault<'pascalCase' extends keyof OptionsType ? OptionsType['pascalCase'] : undefined, false>,
 WithDefault<'preserveConsecutiveUppercase' extends keyof OptionsType ? OptionsType['preserveConsecutiveUppercase'] : undefined, false>,
 WithDefault<'exclude' extends keyof OptionsType ? OptionsType['exclude'] : undefined, EmptyTuple>,
-WithDefault<'stopPaths' extends keyof OptionsType ? OptionsType['stopPaths'] : undefined, EmptyTuple>
+WithDefault<'stopPaths' extends keyof OptionsType ? OptionsType['stopPaths'] : undefined, EmptyTuple>,
+WithDefault<'excludeChildren' extends keyof OptionsType ? OptionsType['excludeChildren'] : undefined, EmptyTuple>,
+WithDefault<'overrides' extends keyof OptionsType ? OptionsType['overrides'] : undefined, EmptyTuple>
 >;

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,20 @@ Default: `[]`
 
 Exclude keys from being camel-cased.
 
+##### excludeChildren
+
+Type: `Array<string | RegExp>`\
+Default: `[]`
+
+Exclude children of given keys from being camel-cased.
+
+##### overrides
+
+Type: `Array<[string | RegExp, string]>`\
+Default: `[]`
+
+Override keys with a custom value. The first element of the tuple is the key to match, and the second element is the value to use instead.
+
 ##### deep
 
 Type: `boolean`\
@@ -139,7 +153,7 @@ camelcaseKeys(object, {
 	stopPaths: [
 		'a_c.c_e'
 	]
-}),
+})
 /*
 {
 	aB: 1,

--- a/test.js
+++ b/test.js
@@ -15,6 +15,40 @@ test('exclude option', t => {
 	t.deepEqual(camelcaseKeys({'foo-bar': true}, {exclude: [/^f/]}), {'foo-bar': true});
 });
 
+test('excludeChildren option', t => {
+	t.deepEqual(
+		camelcaseKeys(
+			// eslint-disable-next-line camelcase
+			{a_b: 1, a_c: {c_d: 1, c_e: {e_f: 1, g_h: 1, h_i: {j_k: 1}}}}
+			, {deep: true, excludeChildren: ['c_e']}),
+		// eslint-disable-next-line camelcase
+		{aB: 1, aC: {cD: 1, cE: {e_f: 1, g_h: 1, h_i: {jK: 1}}}},
+	);
+});
+
+test('overrides option', t => {
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({foo_bar: true, obj: {one_two: false, arr: [{three_four: true}]}}, {deep: true, overrides: [['foo_bar', 'foo_bar_override']]}),
+		// eslint-disable-next-line camelcase
+		{foo_bar_override: true, obj: {oneTwo: false, arr: [{threeFour: true}]}},
+	);
+
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({foo_bar: true, obj: {one_two: false, arr: [{nested_key: true}]}}, {deep: true, overrides: [['foo_bar', 'foo_bar_override'], ['nested_key', 'nested_key_override']]}),
+		// eslint-disable-next-line camelcase
+		{foo_bar_override: true, obj: {oneTwo: false, arr: [{nested_key_override: true}]}},
+	);
+
+	t.deepEqual(
+		// eslint-disable-next-line camelcase
+		camelcaseKeys({some_regex_match_key: true, obj: {one_two: false, arr: [{three_four: true}]}}, {deep: true, overrides: [[/regex_match/, 'regex_override']]}),
+		// eslint-disable-next-line camelcase
+		{regex_override: true, obj: {oneTwo: false, arr: [{threeFour: true}]}},
+	);
+});
+
 test('deep option', t => {
 	t.deepEqual(
 		// eslint-disable-next-line camelcase


### PR DESCRIPTION
## Description

Add two new options:

- `excludeChildren`
    - Takes in `ReadonlyArray<string | RegExp>`. When a key's parent matches one of the entries in `excludeChildren[]`, the key will not be camelcased
- `overrides`
    - Takes in `ReadonlyArray<[string | RegExp, string]>`. When a key matches the first entry in an `overrides[]` tuple, the key will be manually converted to the second entry in the tuple

## Testing

`yarn test`